### PR TITLE
INPL 118 - Manter multiplas seleções no mesmo Chip, porém limitando a 20 caracteres e apresentando Nome Completo na tooltip

### DIFF
--- a/src/main/java/br/gov/es/infoplan/dto/strategicProject/StrategicProjectIdAndNameDto.java
+++ b/src/main/java/br/gov/es/infoplan/dto/strategicProject/StrategicProjectIdAndNameDto.java
@@ -1,29 +1,48 @@
 package br.gov.es.infoplan.dto.strategicProject;
 
 public class StrategicProjectIdAndNameDto {
-    
-    private int id;
-    private String name;
+  private int id;
 
-    public StrategicProjectIdAndNameDto(int id, String name) {
-        this.id = id;
-        this.name = name;
-    }
+  private String name;
 
-    public StrategicProjectIdAndNameDto(){
-        
-    }
+  private String fullName;
 
-    public int getId() {
-        return id;
-    }
-    public void setId(int id) {
-        this.id = id;
-    }
-    public String getName() {
-        return name;
-    }
-    public void setName(String name) {
-        this.name = name;
-    }
+  public StrategicProjectIdAndNameDto(int id, String name) {
+    this.id = id;
+    this.name = name;
+    this.fullName = name;
+  }
+
+  public StrategicProjectIdAndNameDto(int id, String name, String fullName) {
+    this.id = id;
+    this.name = name;
+    this.fullName = fullName;
+  }
+
+  public StrategicProjectIdAndNameDto() {
+  }
+
+  public int getId() {
+    return this.id;
+  }
+
+  public void setId(int id) {
+    this.id = id;
+  }
+
+  public String getName() {
+    return this.name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public String getFullName() {
+    return this.fullName;
+  }
+
+  public void setFullName(String fullName) {
+    this.fullName = fullName;
+  }
 }

--- a/src/main/java/br/gov/es/infoplan/service/StrategicProjectsService.java
+++ b/src/main/java/br/gov/es/infoplan/service/StrategicProjectsService.java
@@ -492,24 +492,42 @@ public class StrategicProjectsService extends PentahoBIService {
   public List<StrategicProjectIdAndNameDto> consultArea() {
     HashMap<String, Object> params = new HashMap<>();
     params.put("parampCodPortfolio", portfolioId);
-    return consult(targetArea, dataAccessIdArea, params,
-        rs -> new StrategicProjectIdAndNameDto(rs.get("id").asInt(), rs.get("nome").asText()));
+    return consult(
+        targetArea,
+        dataAccessIdArea,
+        params,
+        rs -> new StrategicProjectIdAndNameDto(
+            rs.get("id").asInt(),
+            rs.get("nome").asText(),
+            rs.get("nome_completo").asText()));
   }
 
   public List<StrategicProjectIdAndNameDto> consultProgramaOriginal(String areaId) {
     HashMap<String, Object> params = new HashMap<>();
     params.put("parampCodPortfolio", portfolioId);
     params.put("parampCodArea", areaId);
-    return consult(targetProgramaOriginal, dataAccessIdPrograma, params,
-        rs -> new StrategicProjectIdAndNameDto(rs.get("id").asInt(), rs.get("nome").asText()));
+    return consult(
+        targetProgramaOriginal,
+        dataAccessIdPrograma,
+        params,
+        rs -> new StrategicProjectIdAndNameDto(
+            rs.get("id").asInt(),
+            rs.get("nome").asText(),
+            rs.get("nome_completo").asText()));
   }
 
   public List<StrategicProjectIdAndNameDto> consultProgramaTransversal(String areaId) {
     HashMap<String, Object> params = new HashMap<>();
     params.put("parampCodPortfolio", portfolioId);
     params.put("parampCodArea", areaId);
-    return consult(targetProgramaTransversal, dataAccessIdPrograma, params,
-        rs -> new StrategicProjectIdAndNameDto(rs.get("id").asInt(), rs.get("nome").asText()));
+    return consult(
+        targetProgramaTransversal,
+        dataAccessIdPrograma,
+        params,
+        rs -> new StrategicProjectIdAndNameDto(
+            rs.get("id").asInt(),
+            rs.get("nome").asText(),
+            rs.get("nome_completo").asText()));
   }
 
   public List<StrategicProjectIdAndNameDto> consultProjeto(String areaId, String programaId) {
@@ -517,8 +535,14 @@ public class StrategicProjectsService extends PentahoBIService {
     params.put("parampCodPortfolio", portfolioId);
     params.put("parampCodArea", areaId);
     params.put("parampCodPrograma", programaId);
-    return consult(targetProjeto, dataAccessIdProjeto, params,
-        rs -> new StrategicProjectIdAndNameDto(rs.get("id").asInt(), rs.get("nome").asText()));
+    return consult(
+        targetProjeto,
+        dataAccessIdProjeto,
+        params,
+        rs -> new StrategicProjectIdAndNameDto(
+            rs.get("id").asInt(),
+            rs.get("nome").asText(),
+            rs.get("nome_completo").asText()));
   }
 
   public List<StrategicProjectIdAndNameDto> consultEntrega(String areaId, String programaId, String projetoId) {
@@ -527,14 +551,26 @@ public class StrategicProjectsService extends PentahoBIService {
     params.put("parampCodArea", areaId);
     params.put("parampCodPrograma", programaId);
     params.put("parampCodProjeto", projetoId);
-    return consult(targetEntrega, dataAccessIdEntrega, params,
-        rs -> new StrategicProjectIdAndNameDto(rs.get("id").asInt(), rs.get("nome").asText()));
+    return consult(
+        targetEntrega,
+        dataAccessIdEntrega,
+        params,
+        rs -> new StrategicProjectIdAndNameDto(
+            rs.get("id").asInt(),
+            rs.get("nome").asText(),
+            rs.get("nome_completo").asText()));
   }
 
   public List<StrategicProjectIdAndNameDto> consultOrgao() {
     HashMap<String, Object> params = new HashMap<>();
-    return consult(targetOrgao, dataAccessIdOrgao, params,
-        rs -> new StrategicProjectIdAndNameDto(rs.get("id").asInt(), rs.get("nome").asText()));
+    return consult(
+        targetOrgao,
+        dataAccessIdOrgao,
+        params,
+        rs -> new StrategicProjectIdAndNameDto(
+            rs.get("id").asInt(),
+            rs.get("nome").asText(),
+            rs.get("nome_completo").asText()));
   }
 
   public List<StrategicProjectIdAndNameDto> consultLocalidade() {


### PR DESCRIPTION
- [x] Alterado o DTO do _StrategicProjectIdAndName_ para incluir um campo/propriedade "_fullName_" (opcional, visto que nem todas as entidades possuem esse campo);
- [x] Alterado o _StrategicProjectsService_ para incluir o campo "_nome_completo_" em todas as chamadas ao BI (no caso das entidades que possuem tal campo).