### PR TITLE
INPL 132 - Ordenação dos Filtros de Localidades na Tela de Projetos Estratégicos

### DIFF
--- a/src/main/java/br/gov/es/infoplan/dto/strategicProject/StrategicProjectIdAndNameDto.java
+++ b/src/main/java/br/gov/es/infoplan/dto/strategicProject/StrategicProjectIdAndNameDto.java
@@ -7,6 +7,10 @@ public class StrategicProjectIdAndNameDto {
 
   private String fullName;
 
+  private String tipo;
+
+  private int microregiaoId;
+
   public StrategicProjectIdAndNameDto(int id, String name) {
     this.id = id;
     this.name = name;
@@ -17,6 +21,14 @@ public class StrategicProjectIdAndNameDto {
     this.id = id;
     this.name = name;
     this.fullName = fullName;
+  }
+
+  public StrategicProjectIdAndNameDto(int id, String name, String tipo, int microregiaoId) {
+    this.id = id;
+    this.name = name;
+    this.fullName = name;
+    this.tipo = tipo;
+    this.microregiaoId = microregiaoId;
   }
 
   public StrategicProjectIdAndNameDto() {
@@ -44,5 +56,21 @@ public class StrategicProjectIdAndNameDto {
 
   public void setFullName(String fullName) {
     this.fullName = fullName;
+  }
+
+  public String getTipo() {
+    return tipo;
+  }
+
+  public void setTipo(String tipo) {
+    this.tipo = tipo;
+  }
+
+  public int getMicroregiaoId() {
+    return microregiaoId;
+  }
+
+  public void setMicroregiaoId(int microregiaoId) {
+    this.microregiaoId = microregiaoId;
   }
 }

--- a/src/main/java/br/gov/es/infoplan/service/StrategicProjectsService.java
+++ b/src/main/java/br/gov/es/infoplan/service/StrategicProjectsService.java
@@ -576,7 +576,11 @@ public class StrategicProjectsService extends PentahoBIService {
   public List<StrategicProjectIdAndNameDto> consultLocalidade() {
     HashMap<String, Object> params = new HashMap<>();
     return consult(targetLocalidade, dataAccessIdLocalidade, params,
-        rs -> new StrategicProjectIdAndNameDto(rs.get("id").asInt(), rs.get("nome").asText()));
+        rs -> new StrategicProjectIdAndNameDto(
+            rs.get("id").asInt(),
+            rs.get("nome").asText(),
+            rs.get("tipo").asText(),
+            rs.get("microrregiaoId").asInt()));
   }
 
   public List<StrategicProjectTotaisDto> consultTotals(StrategicProjectFilter filter) {


### PR DESCRIPTION
- [x] Na função de listagem de Localidades _(consultLocalidade())_ no _StrategicProjectsService_, alterado para que os campos **tipo** e **microrregiaoId** sejam inclusos na query e retornados.